### PR TITLE
fix: added check for the msg size

### DIFF
--- a/src/kinematics.cpp
+++ b/src/kinematics.cpp
@@ -145,7 +145,7 @@ private:
         for (size_t i = 0; i < msg->name.size(); ++i)
         {
           for (const auto& pair : wheel_joint_map_index) {
-            if (msg->name[i] == pair.first){
+            if (msg->name[i] == pair.first && i < msg->velocity.size()) {
                 w(pair.second) = msg->velocity[i];
                 break;
             }


### PR DESCRIPTION
I don't know the exact logic behind the crash I was experiencing, but the `kinematics` node was crashing with a segfault. After some debugging I traced that the crash happens here:
```cpp
  void join_states_callback(const sensor_msgs::msg::JointState::SharedPtr msg) {
        Eigen::VectorXd w(N);

        // Loop through all joint names and extract the velocities for the specified joints
        for (size_t i = 0; i < msg->name.size(); ++i)
        {
          for (const auto& pair : wheel_joint_map_index) {
            if (msg->name[i] == pair.first) {
                w(pair.second) = msg->velocity[i];
                break;
            }
          }
        }
     }
```
Due to the size of `msg->velocity` sometimes being inferior to the number of wheels. A simple `i < msg->velocity.size()` check apparently fixed the issue and didn't break anything.